### PR TITLE
Kba/minor fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4714,6 +4714,12 @@
         "node": ">=12"
       }
     },
+    "node_modules/@polka/url": {
+      "version": "1.0.0-next.25",
+      "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.25.tgz",
+      "integrity": "sha512-j7P6Rgr3mmtdkeDGTe0E/aYyWEWVtc5yFXtHCRHs28/jptDEWfaVOc5T7cblqy1XKPPfCxJc/8DwQ5YgLOZOVQ==",
+      "dev": true
+    },
     "node_modules/@popperjs/core": {
       "version": "2.4.4",
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.4.4.tgz",
@@ -5704,6 +5710,18 @@
       "dev": true,
       "peerDependencies": {
         "acorn": "^8"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.3",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.3.tgz",
+      "integrity": "sha512-MxXdReSRhGO7VlFe1bRG/oI7/mdLV9B9JJT0N8vZOhF7gFRR5l3M8W9G8JxmKV+JC5mGqJ0QvqfSOLsCPa4nUw==",
+      "dev": true,
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/agent-base": {
@@ -7013,8 +7031,7 @@
     "node_modules/debounce": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/debounce/-/debounce-1.2.1.tgz",
-      "integrity": "sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug==",
-      "peer": true
+      "integrity": "sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug=="
     },
     "node_modules/debug": {
       "version": "4.3.4",
@@ -7386,6 +7403,12 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "peer": true
+    },
+    "node_modules/duplexer": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
+      "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
+      "dev": true
     },
     "node_modules/duplexer2": {
       "version": "0.1.4",
@@ -8455,6 +8478,21 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true
     },
+    "node_modules/gzip-size": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-6.0.0.tgz",
+      "integrity": "sha512-ax7ZYomf6jqPTQ4+XCpUGyXKHk5WweS+e05MBO4/y3WJ5RkmPXNKvX+bx1behVILVwr6JSQvZAku021CHPXG3Q==",
+      "dev": true,
+      "dependencies": {
+        "duplexer": "^0.1.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/handle-thing": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-2.0.1.tgz",
@@ -8644,6 +8682,12 @@
           "url": "https://patreon.com/mdevils"
         }
       ]
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true
     },
     "node_modules/html-minifier-terser": {
       "version": "6.1.0",
@@ -10026,6 +10070,15 @@
       "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.46.0.tgz",
       "integrity": "sha512-ADwtLIIww+9FKybWscd7OCfm9odsFYHImBRI1v9AviGce55QY8raT+9ihH8jX/E/e6QVSGM+pKj4jSUSRmALNQ==",
       "peer": true
+    },
+    "node_modules/mrmime": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.0.tgz",
+      "integrity": "sha512-eu38+hdgojoyq63s+yTpN4XMBdt5l8HhMhc4VKLO9KM5caLIBvUm4thi7fFaxyTmCKeNnXZ5pAlBwCUnhA09uw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/ms": {
       "version": "2.1.2",
@@ -13080,6 +13133,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/opener": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.2.tgz",
+      "integrity": "sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==",
+      "dev": true,
+      "bin": {
+        "opener": "bin/opener-bin.js"
+      }
+    },
     "node_modules/p-each-series": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-2.2.0.tgz",
@@ -15401,6 +15463,20 @@
         "node": ">=4"
       }
     },
+    "node_modules/sirv": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/sirv/-/sirv-2.0.4.tgz",
+      "integrity": "sha512-94Bdh3cC2PKrbgSOUqTiGPWVZeSiXfKOVZNJniWoqrWrRkB1CJzBU3NEbiTsPcYy1lDsANA/THzS+9WBiy5nfQ==",
+      "dev": true,
+      "dependencies": {
+        "@polka/url": "^1.0.0-next.24",
+        "mrmime": "^2.0.0",
+        "totalist": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -16078,6 +16154,15 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/totalist": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz",
+      "integrity": "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
@@ -16591,6 +16676,74 @@
         }
       }
     },
+    "node_modules/webpack-bundle-analyzer": {
+      "version": "4.10.2",
+      "resolved": "https://registry.npmjs.org/webpack-bundle-analyzer/-/webpack-bundle-analyzer-4.10.2.tgz",
+      "integrity": "sha512-vJptkMm9pk5si4Bv922ZbKLV8UTT4zib4FPgXMhgzUny0bfDDkLXAVQs3ly3fS4/TN9ROFtb0NFrm04UXFE/Vw==",
+      "dev": true,
+      "dependencies": {
+        "@discoveryjs/json-ext": "0.5.7",
+        "acorn": "^8.0.4",
+        "acorn-walk": "^8.0.0",
+        "commander": "^7.2.0",
+        "debounce": "^1.2.1",
+        "escape-string-regexp": "^4.0.0",
+        "gzip-size": "^6.0.0",
+        "html-escaper": "^2.0.2",
+        "opener": "^1.5.2",
+        "picocolors": "^1.0.0",
+        "sirv": "^2.0.3",
+        "ws": "^7.3.1"
+      },
+      "bin": {
+        "webpack-bundle-analyzer": "lib/bin/analyzer.js"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      }
+    },
+    "node_modules/webpack-bundle-analyzer/node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/webpack-bundle-analyzer/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/webpack-bundle-analyzer/node_modules/ws": {
+      "version": "7.5.10",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/webpack-cli": {
       "version": "5.1.4",
       "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-5.1.4.tgz",
@@ -17063,6 +17216,7 @@
         "ts-loader": "^9.5.1",
         "typescript": "5.4.2",
         "webpack": "^5.89.0",
+        "webpack-bundle-analyzer": "^4.10.2",
         "webpack-cli": "^5.1.4",
         "webpack-dev-server": "^4.15.1"
       }
@@ -20599,6 +20753,12 @@
         "config-chain": "^1.1.11"
       }
     },
+    "@polka/url": {
+      "version": "1.0.0-next.25",
+      "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.25.tgz",
+      "integrity": "sha512-j7P6Rgr3mmtdkeDGTe0E/aYyWEWVtc5yFXtHCRHs28/jptDEWfaVOc5T7cblqy1XKPPfCxJc/8DwQ5YgLOZOVQ==",
+      "dev": true
+    },
     "@popperjs/core": {
       "version": "2.4.4",
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.4.4.tgz",
@@ -21451,6 +21611,15 @@
       "integrity": "sha512-cmMwop9x+8KFhxvKrKfPYmN6/pKTYYHBqLa0DfvVZcKMJWNyWLnaqND7dx/qn66R7ewM1UX5XMaDVP5wlVTaVA==",
       "dev": true,
       "requires": {}
+    },
+    "acorn-walk": {
+      "version": "8.3.3",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.3.tgz",
+      "integrity": "sha512-MxXdReSRhGO7VlFe1bRG/oI7/mdLV9B9JJT0N8vZOhF7gFRR5l3M8W9G8JxmKV+JC5mGqJ0QvqfSOLsCPa4nUw==",
+      "dev": true,
+      "requires": {
+        "acorn": "^8.11.0"
+      }
     },
     "agent-base": {
       "version": "7.1.1",
@@ -22441,8 +22610,7 @@
     "debounce": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/debounce/-/debounce-1.2.1.tgz",
-      "integrity": "sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug==",
-      "peer": true
+      "integrity": "sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug=="
     },
     "debug": {
       "version": "4.3.4",
@@ -22720,6 +22888,12 @@
           "peer": true
         }
       }
+    },
+    "duplexer": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
+      "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
+      "dev": true
     },
     "duplexer2": {
       "version": "0.1.4",
@@ -23556,6 +23730,15 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true
     },
+    "gzip-size": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-6.0.0.tgz",
+      "integrity": "sha512-ax7ZYomf6jqPTQ4+XCpUGyXKHk5WweS+e05MBO4/y3WJ5RkmPXNKvX+bx1behVILVwr6JSQvZAku021CHPXG3Q==",
+      "dev": true,
+      "requires": {
+        "duplexer": "^0.1.2"
+      }
+    },
     "handle-thing": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-2.0.1.tgz",
@@ -23686,6 +23869,12 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.4.0.tgz",
       "integrity": "sha512-igBTJcNNNhvZFRtm8uA6xMY6xYleeDwn3PeBCkDz7tHttv4F2hsDI2aPgNERWzvRcNYHNT3ymRaQzllmXj4YsQ==",
+      "dev": true
+    },
+    "html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true
     },
     "html-minifier-terser": {
@@ -24690,6 +24879,12 @@
       "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.46.0.tgz",
       "integrity": "sha512-ADwtLIIww+9FKybWscd7OCfm9odsFYHImBRI1v9AviGce55QY8raT+9ihH8jX/E/e6QVSGM+pKj4jSUSRmALNQ==",
       "peer": true
+    },
+    "mrmime": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.0.tgz",
+      "integrity": "sha512-eu38+hdgojoyq63s+yTpN4XMBdt5l8HhMhc4VKLO9KM5caLIBvUm4thi7fFaxyTmCKeNnXZ5pAlBwCUnhA09uw==",
+      "dev": true
     },
     "ms": {
       "version": "2.1.2",
@@ -26838,6 +27033,12 @@
         "is-wsl": "^2.2.0"
       }
     },
+    "opener": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.2.tgz",
+      "integrity": "sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==",
+      "dev": true
+    },
     "p-each-series": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-2.2.0.tgz",
@@ -27167,6 +27368,7 @@
         "ts-loader": "^9.5.1",
         "typescript": "5.4.2",
         "webpack": "^5.89.0",
+        "webpack-bundle-analyzer": "*",
         "webpack-cli": "^5.1.4",
         "webpack-dev-server": "^4.15.1"
       }
@@ -28663,6 +28865,17 @@
         }
       }
     },
+    "sirv": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/sirv/-/sirv-2.0.4.tgz",
+      "integrity": "sha512-94Bdh3cC2PKrbgSOUqTiGPWVZeSiXfKOVZNJniWoqrWrRkB1CJzBU3NEbiTsPcYy1lDsANA/THzS+9WBiy5nfQ==",
+      "dev": true,
+      "requires": {
+        "@polka/url": "^1.0.0-next.24",
+        "mrmime": "^2.0.0",
+        "totalist": "^3.0.0"
+      }
+    },
     "slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -29178,6 +29391,12 @@
       "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
       "dev": true
     },
+    "totalist": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz",
+      "integrity": "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==",
+      "dev": true
+    },
     "tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
@@ -29548,6 +29767,47 @@
         "terser-webpack-plugin": "^5.3.10",
         "watchpack": "^2.4.0",
         "webpack-sources": "^3.2.3"
+      }
+    },
+    "webpack-bundle-analyzer": {
+      "version": "4.10.2",
+      "resolved": "https://registry.npmjs.org/webpack-bundle-analyzer/-/webpack-bundle-analyzer-4.10.2.tgz",
+      "integrity": "sha512-vJptkMm9pk5si4Bv922ZbKLV8UTT4zib4FPgXMhgzUny0bfDDkLXAVQs3ly3fS4/TN9ROFtb0NFrm04UXFE/Vw==",
+      "dev": true,
+      "requires": {
+        "@discoveryjs/json-ext": "0.5.7",
+        "acorn": "^8.0.4",
+        "acorn-walk": "^8.0.0",
+        "commander": "^7.2.0",
+        "debounce": "^1.2.1",
+        "escape-string-regexp": "^4.0.0",
+        "gzip-size": "^6.0.0",
+        "html-escaper": "^2.0.2",
+        "opener": "^1.5.2",
+        "picocolors": "^1.0.0",
+        "sirv": "^2.0.3",
+        "ws": "^7.3.1"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+          "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+          "dev": true
+        },
+        "escape-string-regexp": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+          "dev": true
+        },
+        "ws": {
+          "version": "7.5.10",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+          "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+          "dev": true,
+          "requires": {}
+        }
       }
     },
     "webpack-cli": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2007,9 +2007,9 @@
       }
     },
     "node_modules/@eavfw/apps": {
-      "version": "1.4.0-vnext.27",
-      "resolved": "https://registry.npmjs.org/@eavfw/apps/-/apps-1.4.0-vnext.27.tgz",
-      "integrity": "sha512-HdkoNiHKmdBRR/rGarwbofaI5LW1L2HC8rGXzaYOrsEZ5NBHoZiypxuujEyFFXconky14QtcWSjbJdS7dl5sIg==",
+      "version": "1.4.0-vnext.32",
+      "resolved": "https://registry.npmjs.org/@eavfw/apps/-/apps-1.4.0-vnext.32.tgz",
+      "integrity": "sha512-ZU7UyNaGJDUEpkhiYLtx3dGx9Z1glCD+4b3mCh1aZwVyJ0Ng72eO6c1U16QKsvbdTxi89lKV3VwFYENdfxM56w==",
       "peer": true,
       "dependencies": {
         "@eavfw/expressions": "*",
@@ -2132,9 +2132,9 @@
       }
     },
     "node_modules/@eavfw/manifest": {
-      "version": "1.5.0-vnext.10",
-      "resolved": "https://registry.npmjs.org/@eavfw/manifest/-/manifest-1.5.0-vnext.10.tgz",
-      "integrity": "sha512-AbxIhGBiku73JNJmc4EJm2ms9cZZwYmLU07krSIjnmtuqL1H1QNnepcdfl75I9UBoaOjHp2cnyJH9mxBv8vK7w==",
+      "version": "1.5.0-vnext.14",
+      "resolved": "https://registry.npmjs.org/@eavfw/manifest/-/manifest-1.5.0-vnext.14.tgz",
+      "integrity": "sha512-ndVAb9qzM7PYH9i6ngGHO4MwlATp/B48QtfHt8J7pOtKkBqL0v7hf7hSzN1nb3riBDshWz2/ureU70PiTnIGug==",
       "peer": true,
       "peerDependencies": {
         "react": "^18.2.0",
@@ -5154,16 +5154,6 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/classnames": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@types/classnames/-/classnames-2.3.1.tgz",
-      "integrity": "sha512-zeOWb0JGBoVmlQoznvqXbE0tEC/HONsnoUNH19Hc96NFsTAwTXbTqb8FMYkru1F/iqp7a18Ws3nWJvtA1sHD1A==",
-      "deprecated": "This is a stub types definition. classnames provides its own type definitions, so you do not need this installed.",
-      "dev": true,
-      "dependencies": {
-        "classnames": "*"
-      }
-    },
     "node_modules/@types/clone-deep": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@types/clone-deep/-/clone-deep-4.0.1.tgz",
@@ -6376,7 +6366,8 @@
     "node_modules/classnames": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
-      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow=="
+      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
+      "peer": true
     },
     "node_modules/clean-css": {
       "version": "5.3.3",
@@ -13916,15 +13907,6 @@
       "integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==",
       "peer": true
     },
-    "node_modules/react-icons": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.12.0.tgz",
-      "integrity": "sha512-IBaDuHiShdZqmfc/TwHu6+d6k2ltNCf3AszxNmjJc1KUfXdEeRJOKyNvLmAHaarhzGmTSVygNdyu8/opXv2gaw==",
-      "dev": true,
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
     "node_modules/react-is": {
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
@@ -17010,15 +16992,10 @@
       "version": "1.0.0-vnext.36",
       "license": "MIT",
       "dependencies": {
-        "classnames": "^2.5.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
       },
-      "devDependencies": {
-        "@types/classnames": "^2.3.1",
-        "html-webpack-plugin": "^5.6.0",
-        "react-icons": "^4.11.0"
-      },
+      "devDependencies": {},
       "peerDependencies": {
         "@griffel/react": "1.5.23",
         "@opentelemetry/api": "^1.8.0"
@@ -17037,12 +17014,12 @@
       },
       "peerDependencies": {
         "@craftjs/core": "^0.2.4",
-        "@eavfw/apps": "^1.4.0-vnext.27",
+        "@eavfw/apps": "^1.4.0-vnext.32",
         "@eavfw/designer": "^1.1.1",
         "@eavfw/designer-core": "^1.1.1",
         "@eavfw/designer-nodes": "^1.1.2",
         "@eavfw/forms": "^1.2.0-vnext.8",
-        "@eavfw/manifest": "^1.5.0-vnext.10",
+        "@eavfw/manifest": "^1.5.0-vnext.14",
         "@eavfw/utils": "^1.1.0-vnext.1",
         "@fluentui/react-components": "=>9.46.0 <9.49.2",
         "@rjsf/core": "5.17.1",
@@ -18491,9 +18468,9 @@
       "dev": true
     },
     "@eavfw/apps": {
-      "version": "1.4.0-vnext.27",
-      "resolved": "https://registry.npmjs.org/@eavfw/apps/-/apps-1.4.0-vnext.27.tgz",
-      "integrity": "sha512-HdkoNiHKmdBRR/rGarwbofaI5LW1L2HC8rGXzaYOrsEZ5NBHoZiypxuujEyFFXconky14QtcWSjbJdS7dl5sIg==",
+      "version": "1.4.0-vnext.32",
+      "resolved": "https://registry.npmjs.org/@eavfw/apps/-/apps-1.4.0-vnext.32.tgz",
+      "integrity": "sha512-ZU7UyNaGJDUEpkhiYLtx3dGx9Z1glCD+4b3mCh1aZwVyJ0Ng72eO6c1U16QKsvbdTxi89lKV3VwFYENdfxM56w==",
       "peer": true,
       "requires": {
         "@eavfw/expressions": "*",
@@ -18564,21 +18541,17 @@
       "requires": {}
     },
     "@eavfw/manifest": {
-      "version": "1.5.0-vnext.10",
-      "resolved": "https://registry.npmjs.org/@eavfw/manifest/-/manifest-1.5.0-vnext.10.tgz",
-      "integrity": "sha512-AbxIhGBiku73JNJmc4EJm2ms9cZZwYmLU07krSIjnmtuqL1H1QNnepcdfl75I9UBoaOjHp2cnyJH9mxBv8vK7w==",
+      "version": "1.5.0-vnext.14",
+      "resolved": "https://registry.npmjs.org/@eavfw/manifest/-/manifest-1.5.0-vnext.14.tgz",
+      "integrity": "sha512-ndVAb9qzM7PYH9i6ngGHO4MwlATp/B48QtfHt8J7pOtKkBqL0v7hf7hSzN1nb3riBDshWz2/ureU70PiTnIGug==",
       "peer": true,
       "requires": {}
     },
     "@eavfw/quickform-core": {
       "version": "file:packages/core",
       "requires": {
-        "@types/classnames": "^2.3.1",
-        "classnames": "^2.5.1",
-        "html-webpack-plugin": "^5.6.0",
         "react": "^18.2.0",
-        "react-dom": "^18.2.0",
-        "react-icons": "^4.11.0"
+        "react-dom": "^18.2.0"
       }
     },
     "@eavfw/quickform-designer": {
@@ -20959,15 +20932,6 @@
         "@types/node": "*"
       }
     },
-    "@types/classnames": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@types/classnames/-/classnames-2.3.1.tgz",
-      "integrity": "sha512-zeOWb0JGBoVmlQoznvqXbE0tEC/HONsnoUNH19Hc96NFsTAwTXbTqb8FMYkru1F/iqp7a18Ws3nWJvtA1sHD1A==",
-      "dev": true,
-      "requires": {
-        "classnames": "*"
-      }
-    },
     "@types/clone-deep": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@types/clone-deep/-/clone-deep-4.0.1.tgz",
@@ -21971,7 +21935,8 @@
     "classnames": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
-      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow=="
+      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
+      "peer": true
     },
     "clean-css": {
       "version": "5.3.3",
@@ -27497,13 +27462,6 @@
       "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.2.tgz",
       "integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==",
       "peer": true
-    },
-    "react-icons": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.12.0.tgz",
-      "integrity": "sha512-IBaDuHiShdZqmfc/TwHu6+d6k2ltNCf3AszxNmjJc1KUfXdEeRJOKyNvLmAHaarhzGmTSVygNdyu8/opXv2gaw==",
-      "dev": true,
-      "requires": {}
     },
     "react-is": {
       "version": "18.2.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "release-designer": "npm run release --workspace packages/designer",
     "release-inputs": "npm run release --workspace packages/inputs",
     "release-querybuilder": "npm run release --workspace packages/querybuilder",
-    "eavfw-link": "npm link @eavfw/apps @eavfw/next @eavfw/expressions @eavfw/manifest @eavfw/hooks @eavfw/forms @eavfw/utils @eavfw/designer @eavfw/designer-core @eavfw/designer-nodes",
+    "eavfw-link": "npm link @eavfw/apps @eavfw/next @eavfw/expressions @eavfw/manifest @eavfw/hooks @eavfw/forms @eavfw/utils",
     "playground": "npm --workspace packages/playground run dev"
   },
   "config": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "release-designer": "npm run release --workspace packages/designer",
     "release-inputs": "npm run release --workspace packages/inputs",
     "release-querybuilder": "npm run release --workspace packages/querybuilder",
-    "eavfw-link": "npm link @eavfw/apps @eavfw/next @eavfw/expressions @eavfw/manifest @eavfw/hooks @eavfw/forms @eavfw/utils",
+   "eavfw-link": "npm link @eavfw/apps @eavfw/next @eavfw/expressions @eavfw/manifest @eavfw/hooks @eavfw/forms @eavfw/utils @eavfw/designer @eavfw/designer-core @eavfw/designer-nodes",
     "playground": "npm --workspace packages/playground run dev"
   },
   "config": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -2,7 +2,6 @@
   "version": "1.0.0-vnext.36",
   "name": "@eavfw/quickform-core",
   "dependencies": {
-    "classnames": "^2.5.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },
@@ -11,9 +10,6 @@
     "@opentelemetry/api": "^1.8.0"
   },
   "devDependencies": {
-    "react-icons": "^4.11.0",
-    "@types/classnames": "^2.3.1",
-    "html-webpack-plugin": "^5.6.0"
   },
   "license": "MIT",
   "files": [

--- a/packages/core/src/components/icons/IconResolver.tsx
+++ b/packages/core/src/components/icons/IconResolver.tsx
@@ -4,16 +4,18 @@ import { UserIcon } from "./UserIcon";
 import { IconProps } from "./iconProps";
 import { Checkmark } from '../icons/Checkmark';
 
-export type IconType = "Email" | "Phone" | "User";
+export type IconType = "Email" | "Phone" | "User" | "Checkmark" | "None";
 export type IconResolverProps = {
     type?: IconType,
 } & IconProps
 
 export const IconResolver: React.FC<IconResolverProps> = ({ type, color, className, size, style }): JSX.Element => {
     switch (type) {
-        case "Email": return <EmailIcon className={className} color={color} size={size} style={style} />
-        case "Phone": return <TelephoneIcon className={className} color={color} size={size} style={style} />
-        case "User": return <UserIcon className={className} color={color} size={size} style={style} />
-        default: return <Checkmark className={className} color={color} size={size} style={style} />;
+        case "Email": return <EmailIcon className={className} color={color} size={size} style={style} />;
+        case "Phone": return <TelephoneIcon className={className} color={color} size={size} style={style} />;
+        case "User": return <UserIcon className={className} color={color} size={size} style={style} />;
+        case "Checkmark": return <Checkmark className={className} color={color} size={size} style={style} />;
+        case "None": return <></>;
+        default: return <></>;
     }
 }

--- a/packages/core/src/components/index.ts
+++ b/packages/core/src/components/index.ts
@@ -15,6 +15,7 @@ export { QuickForm } from "./QuickForm";
 export { Spinner } from "./spinner/Spinner";
 export { Intro } from "./intro/Intro";
 export { QuickFormContainer } from "./container/QuickFormContainer";
+export { ModernQuickFormContainer } from "./modern-container/ModernQuickformContainer";
 export { SlideRenderer } from "./renderers/slide-renderer/SlideRenderer";
 export { QuestionHeading } from "./question/components/QuestionHeading";
 // import "./question/input-types";

--- a/packages/core/src/components/modern-container/ModernQuickformContainer.tsx
+++ b/packages/core/src/components/modern-container/ModernQuickformContainer.tsx
@@ -1,3 +1,4 @@
+"use client";
 import { ErrorPopup, quickformtokens, useQuickForm } from "../../index";
 import { makeStyles, shorthands } from "@griffel/react";
 import React, { PropsWithChildren } from "react";

--- a/packages/core/src/components/modern-container/ModernQuickformContainer.tsx
+++ b/packages/core/src/components/modern-container/ModernQuickformContainer.tsx
@@ -1,0 +1,69 @@
+import { ErrorPopup, quickformtokens, useQuickForm } from "../../index";
+import { makeStyles, shorthands } from "@griffel/react";
+import React, { PropsWithChildren } from "react";
+
+const useStyles = makeStyles({
+    root: {
+        ...shorthands.padding("20px", "20px", "20px", "20px"),
+        ...shorthands.margin("20px", "0px"),
+        ...shorthands.borderRadius("20px"),
+        boxShadow: 'rgba(100, 100, 111, 0.2) 0px 7px 29px 0px',
+        // backgroundColor: quickformtokens.background || "white"
+    }
+})
+
+type ModernQuickFormContainerProps = {
+    title: string,
+    subtitle: string,
+}
+
+export const ModernQuickFormContainer: React.FC<PropsWithChildren<ModernQuickFormContainerProps>> = ({ children, subtitle, title }) => {
+
+    const styles = useStyles();
+    const { state: { errorMsg }, cssVariables } = useQuickForm();
+    return (
+        <div
+            id="QuickForm"
+            className={styles.root}
+            style={cssVariables}
+        >
+            <ErrorPopup
+                message={errorMsg}
+            />
+            <Headline
+                text={title}
+                fontWeight={800}
+                color={quickformtokens.primary}
+                lineHeight={1.2}
+            />
+            <Headline
+                text={subtitle}
+                fontWeight={300}
+                color={"inherit"}
+                lineHeight={1.1}
+            />
+            <div>
+                {children}
+            </div>
+        </div >
+
+    )
+}
+
+const Headline: React.FC<{ text: string, fontWeight: number, color: string, lineHeight: number }> = ({ text, fontWeight, color, lineHeight }) => {
+    return (
+        <h1
+            style={
+                {
+                    textAlign: "center",
+                    fontSize: "36px",
+                    fontWeight: fontWeight,
+                    color: color,
+                    lineHeight: lineHeight,
+                    margin: 0
+                }
+            }>
+            {text}
+        </h1>
+    )
+}

--- a/packages/core/src/components/renderers/slide-renderer/SlideRenderer.tsx
+++ b/packages/core/src/components/renderers/slide-renderer/SlideRenderer.tsx
@@ -15,16 +15,17 @@ export const SlideRenderer: React.FC = () => {
 
     const currentSlide: SlideModel = state.slides[state.currIdx];
     const buttonText: string = currentSlide?.buttonText ?? "OK";
-    const showPressEnter: boolean = currentSlide?.questions?.some(q => q.inputType === "multilinetext" && q.isActive) === false;
+    // If not disabled by state.showPressEnter being set to false, and if the slide has questions, and all questions are not multilinetext, show the press enter message
+    const showPressEnter: boolean = (state.showPressEnter === false) ? false : (currentSlide?.questions !== undefined && currentSlide.questions.every(q => q.inputType !== "multilinetext" || !q.isActive));
 
     /* KBA - Leaving this for now - have to get back to it since we never actually set .isActive property on question.. so we cant use it to condition with at the moment.. */
     // const showPressEnter: boolean = currentSlide.questions.some(q => q.inputType === "multilinetext" && q.isActive) === false;
-    console.log("showPressEnter", showPressEnter);
-    console.log("showPressEnterCondition", currentSlide?.questions?.some(q => q.inputType === "multilinetext" && q.isActive));
-    console.log("showPressEnterCurrentSlide", currentSlide);
+    // console.log("showPressEnter", showPressEnter);
+    // console.log("showPressEnterCondition", currentSlide?.questions?.some(q => q.inputType === "multilinetext" && q.isActive));
+    // console.log("showPressEnterCurrentSlide", currentSlide);
 
     /* Listens to enter key pressed */
-    useHandleEnterKeypress("slide", !showPressEnter, goToNextSlide);
+    useHandleEnterKeypress("slide", showPressEnter === false, goToNextSlide);
 
     let nextAllowedEffectTime = useRef(new Date().getTime());
     useEffect(() => {
@@ -52,7 +53,7 @@ export const SlideRenderer: React.FC = () => {
                 showPressEnter={showPressEnter}
                 children={
                     <>
-                        {buttonText}<IconResolver type={currentSlide?.icon} style={{ height: '100%', marginLeft: quickformtokens.gap1 }} color={quickformtokens.onPrimary} size={24} />
+                        {buttonText}<IconResolver type={currentSlide?.icon ?? state.defaultSlideButtonIcon} style={{ height: '100%', marginLeft: quickformtokens.gap1 }} color={quickformtokens.onPrimary} size={24} />
                     </>
                 }
             />

--- a/packages/core/src/components/renderers/slide-renderer/SlideRenderer.tsx
+++ b/packages/core/src/components/renderers/slide-renderer/SlideRenderer.tsx
@@ -14,13 +14,13 @@ export const SlideRenderer: React.FC = () => {
     const [className, setClassName] = useState(state.classes.slide);
 
     const currentSlide: SlideModel = state.slides[state.currIdx];
-    const buttonText: string = currentSlide.buttonText ?? "OK";
-    const showPressEnter: boolean = currentSlide.questions.some(q => q.inputType === "multilinetext" && q.isActive) === false;
+    const buttonText: string = currentSlide?.buttonText ?? "OK";
+    const showPressEnter: boolean = currentSlide?.questions?.some(q => q.inputType === "multilinetext" && q.isActive) === false;
 
     /* KBA - Leaving this for now - have to get back to it since we never actually set .isActive property on question.. so we cant use it to condition with at the moment.. */
     // const showPressEnter: boolean = currentSlide.questions.some(q => q.inputType === "multilinetext" && q.isActive) === false;
     console.log("showPressEnter", showPressEnter);
-    console.log("showPressEnterCondition", currentSlide.questions.some(q => q.inputType === "multilinetext" && q.isActive));
+    console.log("showPressEnterCondition", currentSlide?.questions?.some(q => q.inputType === "multilinetext" && q.isActive));
     console.log("showPressEnterCurrentSlide", currentSlide);
 
     /* Listens to enter key pressed */
@@ -52,7 +52,7 @@ export const SlideRenderer: React.FC = () => {
                 showPressEnter={showPressEnter}
                 children={
                     <>
-                        {buttonText}<IconResolver type={currentSlide.icon} style={{ height: '100%', marginLeft: quickformtokens.gap1 }} color={quickformtokens.onPrimary} size={24} />
+                        {buttonText}<IconResolver type={currentSlide?.icon} style={{ height: '100%', marginLeft: quickformtokens.gap1 }} color={quickformtokens.onPrimary} size={24} />
                     </>
                 }
             />

--- a/packages/core/src/components/slide/Slide.tsx
+++ b/packages/core/src/components/slide/Slide.tsx
@@ -16,7 +16,7 @@ export const Slide: React.FC<SlideProps> = ({ model, className }: SlideProps) =>
         // style={{ display: 'flex', flexDirection: 'column', width: "100%" }}
         >
             {
-                model.rows.map((row, rowIndex) => (
+                model?.rows?.map((row, rowIndex) => (
                     <div
                         id={"row" + rowIndex}
                         key={rowIndex}

--- a/packages/core/src/model/json-definitions/Layout.ts
+++ b/packages/core/src/model/json-definitions/Layout.ts
@@ -10,8 +10,22 @@ export type LayoutDefinition = {
     classes?: Partial<QuickformClassNames>,
     style?: React.CSSProperties;
     tokens?: Partial<QuickFormTokens>;
+    /**
+   * If enabled, when all questions for the slide is filled it auto advances to next slide
+   */
     autoAdvanceSlides?: boolean;
+    /**
+     * If enabled, question numbers are shown in the title
+     */
     enableQuestionNumbers?: boolean;
+    /**
+     * If enabled, the user is shown a message to press enter next to the button on the slide
+     */
+    showPressEnter?: boolean;
+    /**
+     * The icon used for the slide button
+     */
+    defaultSlideButtonIcon?: IconType;
     slides?: { [key: string]: SlideLayout };
 }
 

--- a/packages/core/src/services/defaults/DefaultModelTransformer.ts
+++ b/packages/core/src/services/defaults/DefaultModelTransformer.ts
@@ -92,7 +92,7 @@ function handleLayout(layout: LayoutDefinition, questions: QuickFormQuestionsDef
             const slideModel = new SlideModel();
             slideModel.displayName = slide.title;
             slideModel.buttonText = slide.buttonText ?? layout.defaultNextButtonText;
-            slideModel.icon = slide.icon;
+            slideModel.icon = slide.icon ?? layout.defaultSlideButtonIcon;
 
             if (slide.rows) {
                 slideModel.rows = processRows(slide.rows, slideModel, questions, payload);
@@ -153,7 +153,7 @@ function handleSubmit(submit: QuickFormSubmitDefinition, payload: any): SubmitMo
         Object.entries((schema?.properties ?? {}) as { [key: string]: any })
             .filter(([k, v]) => uiSchema?.[k]?.["ui:widget"] !== "hidden")
             .map(([k, v]) => [k, {
-              
+
                 inputType: v.type === "string" ? "text" : "dropdown",
                 options: v.type === "string" ? undefined : { "Y": "Yes", "N": "No" },
                 placeholder: uiSchema?.[k]?.["ui:placeholder"],
@@ -161,7 +161,7 @@ function handleSubmit(submit: QuickFormSubmitDefinition, payload: any): SubmitMo
                 paragraph: v.description,
                 dataType: v.type,
                 ...uiSchema?.[k]?.["ui:inputProps"] ?? {}
-               
+
             } as QuestionJsonModel])
     );
 
@@ -173,7 +173,7 @@ function handleSubmit(submit: QuickFormSubmitDefinition, payload: any): SubmitMo
     });
 
     return {
-        text: uiSchema["ui:label"] === false ? '': schema?.title ?? submit?.text ?? "Submit QuickForm",
+        text: uiSchema["ui:label"] === false ? '' : schema?.title ?? submit?.text ?? "Submit QuickForm",
         paragraph: uiSchema["ui:label"] === false ? '' : schema?.description,
         buttonText: submit?.buttonText ?? "Submit",
         submitFields: submitFieldsArray,

--- a/packages/core/src/state/QuickformState.ts
+++ b/packages/core/src/state/QuickformState.ts
@@ -1,11 +1,15 @@
 import { SubmitStatus } from "../model/SubmitStatus";
 import { SlideModel } from "../model/SlideModel";
 import { LayoutDefinition, QuickFormModel } from "../model";
+import { IconType } from "../components/icons/IconResolver";
 
 export type QuickformClassNames = { slide: string, slideIsIn: string, slideIsOut: string };
 export type QuickformState = {
     autoAdvanceSlides?: boolean;
     enableQuestionNumbers?: boolean;
+    showPressEnter?: boolean;
+    defaultNextButtonText?: string;
+    defaultSlideButtonIcon?: IconType;
     currIdx: number;
     currStep: number;
     data: QuickFormModel;
@@ -28,6 +32,9 @@ export const defaultState = (data: QuickFormModel = defaultData, layout?: Layout
     const defState = {
         autoAdvanceSlides: layout?.autoAdvanceSlides ?? false,
         enableQuestionNumbers: layout?.enableQuestionNumbers ?? false,
+        showPressEnter: layout?.showPressEnter ?? undefined,
+        defaultNextButtonText: layout?.defaultNextButtonText ?? "Næste",
+        defaultSlideButtonIcon: layout?.defaultSlideButtonIcon ?? undefined,
         classes: layout?.classes ?? {},
         currIdx: 0,
         currStep: data.slides.length > 0 ? 1 : 0,
@@ -43,7 +50,7 @@ export const defaultState = (data: QuickFormModel = defaultData, layout?: Layout
         slides: data.slides,
         submitStatus: { isSubmitting: false, isSubmitError: false, isSubmitSuccess: false },
         totalSteps: data.slides.length,
-        payloadAugments:[]
+        payloadAugments: []
     };
 
     return defState;

--- a/packages/core/src/state/action-handlers/NavigationActionHandler.ts
+++ b/packages/core/src/state/action-handlers/NavigationActionHandler.ts
@@ -46,9 +46,9 @@ export class NavigationActionHandler {
 
     static handleNextSlideAction = (state: QuickformState) => {
         // Filter out questions that are explicitly not visible
-        const visibleQuestions = state.slides[state.currIdx].questions.filter(question => question.visible?.isVisible !== false);
+        const visibleQuestions = state.slides[state.currIdx]?.questions?.filter(question => question.visible?.isVisible !== false);
 
-        if (visibleQuestions.length === 0) {
+        if (visibleQuestions?.length === 0) {
             return { ...state, errorMsg: "No visible questions to answer." };
         }
 

--- a/packages/core/src/style/defaultQuickFormTokens.ts
+++ b/packages/core/src/style/defaultQuickFormTokens.ts
@@ -42,7 +42,7 @@ export const defaultQuickFormTokens: QuickFormTokens = {
     onPrimary: '#ffffff',
     onSecondary: '#000000',
 
-    fontFamily: 'Outfit, Monaco, Consolas',
+    fontFamily: 'Monaco, Consolas',
     headlineFontSize: '2rem',
     subtitleFontSize: '1.5rem',
     paragraphFontSize: '1.3rem',

--- a/packages/core/src/style/defaultQuickFormTokens.ts
+++ b/packages/core/src/style/defaultQuickFormTokens.ts
@@ -42,8 +42,9 @@ export const defaultQuickFormTokens: QuickFormTokens = {
     onPrimary: '#ffffff',
     onSecondary: '#000000',
 
-    fontFamily: 'var(--chivo), Monaco, Consolas',
+    fontFamily: 'Outfit, Monaco, Consolas',
     headlineFontSize: '2rem',
+    subtitleFontSize: '1.5rem',
     paragraphFontSize: '1.3rem',
     paragraphMobileFontSize: '1.9rem',
     btnFontSize: '2rem',

--- a/packages/core/src/style/kbaQuickFormTokens.ts
+++ b/packages/core/src/style/kbaQuickFormTokens.ts
@@ -46,6 +46,7 @@ export const kbaQuickFormTokens: QuickFormTokens = {
     fontFamily: 'Monaco, "Lucida Console", monospace',
 
     headlineFontSize: '2rem',
+    subtitleFontSize: '1.5rem',
     paragraphFontSize: '1rem',
     paragraphMobileFontSize: '1rem',
     btnFontSize: '1.1rem',

--- a/packages/core/src/style/modernQuickFormTokens.ts
+++ b/packages/core/src/style/modernQuickFormTokens.ts
@@ -46,6 +46,7 @@ export const modernQuickFormTokens: QuickFormTokens = {
     fontFamily: 'Outfit, Monaco, monospace',
 
     headlineFontSize: '2rem',
+    subtitleFontSize: '1.5rem',
     paragraphFontSize: '1rem',
     paragraphMobileFontSize: '1rem',
     btnFontSize: '1.1rem',

--- a/packages/core/src/style/quickFormTokensDefinition.ts
+++ b/packages/core/src/style/quickFormTokensDefinition.ts
@@ -33,6 +33,7 @@ type QuickFormTokensBase = {
     /* Typography */
     fontFamily: string,
     headlineFontSize: FontSize;
+    subtitleFontSize: FontSize;
     paragraphFontSize: FontSize;
     paragraphMobileFontSize: FontSize;
     btnFontSize: FontSize,
@@ -81,7 +82,7 @@ export type QuickFormTokens = QuickFormTokensBase & {
  */
 export const defineQuickFormTokens = (...tokens: Array<Partial<QuickFormTokens>>) => {
     // Merges and overrides default tokens with provided ones in reverse order for precedence.
-    const mergedTokens = tokens.reduceRight((newTokens, currentToken) => ({
+    const mergedTokens = tokens.reduce((newTokens, currentToken) => ({
         ...newTokens,
         ...currentToken,
     }), defaultQuickFormTokens);

--- a/packages/designer/package.json
+++ b/packages/designer/package.json
@@ -10,8 +10,8 @@
     "@eavfw/designer-core": "^1.1.1",
     "@eavfw/designer-nodes": "^1.1.2",
     
-    "@eavfw/apps": "^1.4.0-vnext.27",
-    "@eavfw/manifest": "^1.5.0-vnext.10",
+    "@eavfw/apps": "^1.4.0-vnext.32",
+    "@eavfw/manifest": "^1.5.0-vnext.14",
     "@eavfw/forms": "^1.2.0-vnext.8",
     "@eavfw/utils": "^1.1.0-vnext.1",
 

--- a/packages/designer/src/Components/Views/DesignerViews.tsx
+++ b/packages/designer/src/Components/Views/DesignerViews.tsx
@@ -19,6 +19,5 @@ export const DesignerViews = () => {
         {view === "ending" && <QuickFormEndingSettingsView />}
         {view === "layout" && <QuickFormLayoutView slideId={activeSlide} layout={quickformpayload.layout} dispatch={updateQuickFormPayload} />}
         {view === "questions" && <QuickFormQuestionsView dispatch={updateQuickFormPayload} questions={quickformpayload.questions} currentQuestion={activeQuestion} />}
-
     </>
 }

--- a/packages/designer/src/Components/Views/QuickFormSettingsView.tsx
+++ b/packages/designer/src/Components/Views/QuickFormSettingsView.tsx
@@ -13,7 +13,10 @@ import { Controls } from "@eavfw/apps";
 const inputSlideSchema = {
     label: "QuickForm Feature Flags",
     uiSchema: {
-        quickFormTokens: {
+        tokens: {
+        },
+        defaultSlideButtonIcon: {
+            "ui:widget": "select"
         }
     },
     schema: {
@@ -26,7 +29,18 @@ const inputSlideSchema = {
                 type: "boolean"
 
             },
-            quickFormTokens: {
+            showPressEnter: {
+                title: "Show Press Enter",
+                description: "Enable to show a message to press enter next to the button on the slide",
+                type: "boolean"
+            },
+            defaultSlideButtonIcon: {
+                title: "Default Slide Button Icon",
+                description: "The icon used for the slide button",
+                type: "string",
+                enum: ["None", "Email", "Phone", "User", "Checkmark"]
+            },
+            tokens: {
                 title: "Tokens (Variables)",
                 type: "object",
                 properties: {
@@ -39,8 +53,8 @@ const inputSlideSchema = {
 
 function registerToken(key: keyof typeof defaultQuickFormTokens, title: string, description: string, widget: string) {
 
-    const tokensSchema = inputSlideSchema.schema.properties?.quickFormTokens! as JSONSchema7;
-    const uiSchema = inputSlideSchema.uiSchema.quickFormTokens;
+    const tokensSchema = inputSlideSchema.schema.properties?.tokens! as JSONSchema7;
+    const uiSchema = inputSlideSchema.uiSchema.tokens;
     if (tokensSchema && tokensSchema.properties) {
         tokensSchema.properties[key] = {
             title,
@@ -54,69 +68,69 @@ function registerToken(key: keyof typeof defaultQuickFormTokens, title: string, 
     }
 }
 
+// Typography
 registerToken("fontFamily", "Font Used", "The font used", "text");
-
-registerToken("surface", "Surface Color", "The surface color....", "color");
-registerToken("onSurface", "On Surface Color", "The color used on the surface....", "color");
-
-registerToken("background", "Background Color", "The background color used on the webplace where the quickform is used...", "color");
-registerToken("onBackground", "On Background Color", "The color used for text ontop of background color....", "color");
-
-registerToken("secondary", "Secondary Color", "The secondary color used. This is default color for buttons, sliders and components used in input controls", "color");
-registerToken("onSecondary", "On Secondary Color", "The color used for text ontop of secondary color....", "color");
-
-
-registerToken("primary", "Primary Color", "The priamry color used. This is the color used for next buttons and other important elements. Also considered the brand colour", "color");
-registerToken("onPrimary", "On Primary Color", "The color used for text ontop of primary color....", "color");
-
-registerToken("error", "Error Color", "The colour used for containers with errors, aka background colour.", "color");
-registerToken("onError", "On Error Color", "The color used for text ontop of error color....", "color");
-
+registerToken("headlineFontSize", "Headline Font Size", "The size of the headline...", "text");
+registerToken("subtitleFontSize", "Subtitle Font Size", "The size of the subtitle...", "text");
 registerToken("questionHeadlineFontSize", "Question Headline Font Size", "The size of the question headline...", "text");
 registerToken("questionParagraphFontSize", "Question Paragraph Font Size", "The size of question paragraph...", "text");
+
+// Colors
+registerToken("primary", "Primary Color", "The primary color used. This is the color used for primary buttons and other important elements. Also considered the brand colour", "color");
+registerToken("onPrimary", "On Primary Color", "The color used for text on top of primary color....", "color");
+registerToken("secondary", "Secondary Color", "The secondary color used. This is default color for buttons, sliders and components used in input controls", "color");
+registerToken("onSecondary", "On Secondary Color", "The color used for text on top of secondary color....", "color");
+registerToken("error", "Error Color", "The colour used for containers with errors, aka background colour.", "color");
+registerToken("onError", "On Error Color", "The color used for text on top of error color....", "color");
+registerToken("surface", "Surface Color", "The surface color....", "color");
+registerToken("onSurface", "On Surface Color", "The color used on the surface....", "color");
+registerToken("background", "Background Color", "The background color used on the webplace where the quickform is used...", "color");
+registerToken("onBackground", "On Background Color", "The color used for text on top of background color....", "color");
 
 const useQuickformSettingsStyles = makeStyles({
     container: {
         display: 'flex',
         flexDirection: 'row',
-        width: "100%"
+    },
+    previewContainer: {
+        overflow: 'scroll'
     }
 });
 
-
-
 export const QuickFormSettingsView = () => {
-
     const { quickformpayload, updateQuickFormPayload: dispatch } = useQuickFormDefinition();
     const styles = useViewStyles();
     const quickformSettingsStyles = useQuickformSettingsStyles();
     const PreviewComponent = Controls["QuickFormSettingsViewPreviewComponent"];
-
+    console.log("quickformpayloadV1", JSON.stringify(quickformpayload.layout));
     return (
-        <div
-            className={mergeClasses(styles.section, quickformSettingsStyles.container)}
-        >
-            <div className={styles.sectionSlim}>
-                <Form templates={{ FieldTemplate: FieldTemplate, BaseInputTemplate: BaseInputTemplate }}
+        <div className={mergeClasses(styles.section, quickformSettingsStyles.container)}>
+            <div className={mergeClasses(styles.sectionSlim, styles.section)}>
+                <Form templates={{ FieldTemplate, BaseInputTemplate }}
                     validator={validator}
                     {...inputSlideSchema}
-                    formData={quickformpayload.intro}
+                    formData={quickformpayload.layout}
                     onChange={(a, b) => {
                         console.log("change", [a, b]);
-
                         dispatch(old => {
-                            if (!old.layout)
-                                old.layout = {};
-
+                            if (!old.layout) old.layout = {};
                             old.layout.autoAdvanceSlides = a.formData.autoAdvanceSlides;
-                            return { ...old };
+                            old.layout.showPressEnter = a.formData.showPressEnter;
+                            old.layout.tokens = { ...a.formData.tokens };
+                            old.layout.defaultSlideButtonIcon = a.formData.defaultSlideButtonIcon;
+                            console.log("quickformpayload_old", { ...old, layout: { ...old.layout } });
+                            return { ...old, layout: { ...old.layout } };
                         });
                     }}
-                />
+                >
+                    <></>
+                </Form>
             </div>
-            <div>
-                <PreviewComponent />
-            </div>
+            {PreviewComponent &&
+                <div className={mergeClasses(styles.section, quickformSettingsStyles.previewContainer)}>
+                    <PreviewComponent />
+                </div>
+            }
         </div>
-    )
-}
+    );
+};

--- a/packages/designer/src/Components/Views/QuickFormSettingsView.tsx
+++ b/packages/designer/src/Components/Views/QuickFormSettingsView.tsx
@@ -5,10 +5,10 @@ import { FieldTemplate } from "./rjsf/FieldTemplate";
 import { BaseInputTemplate } from "./rjsf/BaseInputTemplate";
 import { useQuickFormDefinition } from "../../Contexts/QuickFormDefContext";
 import { useViewStyles } from "../Styles/useViewStyles.styles";
-import { mergeClasses } from "@fluentui/react-components";
+import { makeStyles, mergeClasses } from "@fluentui/react-components";
 import { JSONSchema7 } from "json-schema";
-import { ModernQuickFormContainer, QuickForm, QuickFormProvider, defaultQuickFormTokens } from "@eavfw/quickform-core";
-import { useState } from "react";
+import { defaultQuickFormTokens } from "@eavfw/quickform-core";
+import { Controls } from "@eavfw/apps";
 
 const inputSlideSchema = {
     label: "QuickForm Feature Flags",
@@ -75,75 +75,48 @@ registerToken("onError", "On Error Color", "The color used for text ontop of err
 registerToken("questionHeadlineFontSize", "Question Headline Font Size", "The size of the question headline...", "text");
 registerToken("questionParagraphFontSize", "Question Paragraph Font Size", "The size of question paragraph...", "text");
 
-type DemoDisplayTypes = "mobile" | "tablet" | "desktop";
-type DemoDisplay = {
-    [key in DemoDisplayTypes]: { width: number, height: number, title: string };
-
-};
-
-const demoDisplays: DemoDisplay = {
-    mobile: {
-        width: 320,
-        height: 568,
-        title: "Mobile"
-
-    },
-    tablet: {
-        width: 768,
-        height: 1024,
-        title: "Tablet"
-    },
-    desktop: {
-        width: 1366,
-        height: 768,
-        title: "Desktop"
+const useQuickformSettingsStyles = makeStyles({
+    container: {
+        display: 'flex',
+        flexDirection: 'row',
+        width: "100%"
     }
+});
 
-};
+
 
 export const QuickFormSettingsView = () => {
 
     const { quickformpayload, updateQuickFormPayload: dispatch } = useQuickFormDefinition();
     const styles = useViewStyles();
-    const [currentDemoDisplay, setCurrentDemoDisplay] = useState<DemoDisplayTypes>("mobile");
-    const tokensSchema = inputSlideSchema.schema.properties?.quickFormTokens! as JSONSchema7;
+    const quickformSettingsStyles = useQuickformSettingsStyles();
+    const PreviewComponent = Controls["QuickFormSettingsViewPreviewComponent"];
 
     return (
-        <div className={mergeClasses(styles.section, styles.sectionSlim)}>
-            <Form templates={{ FieldTemplate: FieldTemplate, BaseInputTemplate: BaseInputTemplate }}
-                validator={validator}
-                {...inputSlideSchema}
-                formData={quickformpayload.intro}
-                onChange={(a, b) => {
-                    console.log("change", [a, b]);
+        <div
+            className={mergeClasses(styles.section, quickformSettingsStyles.container)}
+        >
+            <div className={styles.sectionSlim}>
+                <Form templates={{ FieldTemplate: FieldTemplate, BaseInputTemplate: BaseInputTemplate }}
+                    validator={validator}
+                    {...inputSlideSchema}
+                    formData={quickformpayload.intro}
+                    onChange={(a, b) => {
+                        console.log("change", [a, b]);
 
-                    dispatch(old => {
-                        if (!old.layout)
-                            old.layout = {};
+                        dispatch(old => {
+                            if (!old.layout)
+                                old.layout = {};
 
-                        old.layout.autoAdvanceSlides = a.formData.autoAdvanceSlides;
-                        return { ...old };
-                    });
-                }}
-            >
-                <QuickFormProvider
-                    // Hack to update the form when the payload changes
-                    key={currentDemoDisplay + JSON.stringify(quickformpayload)}
-                    definition={quickformpayload}
-                    payload={{}}
-                    tokens={tokensSchema.properties}
-                >
-                    <ModernQuickFormContainer
-                        title="QuickForm Settings"
-                        subtitle="Customize the look and feel of your QuickForm"
-                    >
-                        <QuickForm />
-                    </ModernQuickFormContainer>
-
-                </QuickFormProvider>
-                <>
-                </>
-            </Form>
+                            old.layout.autoAdvanceSlides = a.formData.autoAdvanceSlides;
+                            return { ...old };
+                        });
+                    }}
+                />
+            </div>
+            <div>
+                <PreviewComponent />
+            </div>
         </div>
     )
 }

--- a/packages/designer/src/Components/Views/QuickFormSettingsView.tsx
+++ b/packages/designer/src/Components/Views/QuickFormSettingsView.tsx
@@ -6,16 +6,14 @@ import { BaseInputTemplate } from "./rjsf/BaseInputTemplate";
 import { useQuickFormDefinition } from "../../Contexts/QuickFormDefContext";
 import { useViewStyles } from "../Styles/useViewStyles.styles";
 import { mergeClasses } from "@fluentui/react-components";
-import { JSONSchema7, JSONSchema7Definition } from "json-schema";
-import { defaultQuickFormTokens } from "@eavfw/quickform-core";
-
-
+import { JSONSchema7 } from "json-schema";
+import { ModernQuickFormContainer, QuickForm, QuickFormProvider, defaultQuickFormTokens } from "@eavfw/quickform-core";
+import { useState } from "react";
 
 const inputSlideSchema = {
     label: "QuickForm Feature Flags",
     uiSchema: {
         quickFormTokens: {
-
         }
     },
     schema: {
@@ -77,17 +75,45 @@ registerToken("onError", "On Error Color", "The color used for text ontop of err
 registerToken("questionHeadlineFontSize", "Question Headline Font Size", "The size of the question headline...", "text");
 registerToken("questionParagraphFontSize", "Question Paragraph Font Size", "The size of question paragraph...", "text");
 
+type DemoDisplayTypes = "mobile" | "tablet" | "desktop";
+type DemoDisplay = {
+    [key in DemoDisplayTypes]: { width: number, height: number, title: string };
+
+};
+
+const demoDisplays: DemoDisplay = {
+    mobile: {
+        width: 320,
+        height: 568,
+        title: "Mobile"
+
+    },
+    tablet: {
+        width: 768,
+        height: 1024,
+        title: "Tablet"
+    },
+    desktop: {
+        width: 1366,
+        height: 768,
+        title: "Desktop"
+    }
+
+};
+
 export const QuickFormSettingsView = () => {
 
-    const { quickformpayload: { intro }, updateQuickFormPayload: dispatch } = useQuickFormDefinition();
+    const { quickformpayload, updateQuickFormPayload: dispatch } = useQuickFormDefinition();
     const styles = useViewStyles();
+    const [currentDemoDisplay, setCurrentDemoDisplay] = useState<DemoDisplayTypes>("mobile");
+    const tokensSchema = inputSlideSchema.schema.properties?.quickFormTokens! as JSONSchema7;
 
     return (
         <div className={mergeClasses(styles.section, styles.sectionSlim)}>
             <Form templates={{ FieldTemplate: FieldTemplate, BaseInputTemplate: BaseInputTemplate }}
                 validator={validator}
                 {...inputSlideSchema}
-                formData={intro}
+                formData={quickformpayload.intro}
                 onChange={(a, b) => {
                     console.log("change", [a, b]);
 
@@ -100,10 +126,24 @@ export const QuickFormSettingsView = () => {
                     });
                 }}
             >
+                <QuickFormProvider
+                    // Hack to update the form when the payload changes
+                    key={currentDemoDisplay + JSON.stringify(quickformpayload)}
+                    definition={quickformpayload}
+                    payload={{}}
+                    tokens={tokensSchema.properties}
+                >
+                    <ModernQuickFormContainer
+                        title="QuickForm Settings"
+                        subtitle="Customize the look and feel of your QuickForm"
+                    >
+                        <QuickForm />
+                    </ModernQuickFormContainer>
+
+                </QuickFormProvider>
                 <>
                 </>
             </Form>
         </div>
     )
-
 }

--- a/packages/designer/src/Types/QuickFormDefinition.ts
+++ b/packages/designer/src/Types/QuickFormDefinition.ts
@@ -1,34 +1,7 @@
 import { Locale } from "./Locale";
 import { ViewNames } from "./ViewNames";
-import { QuickFormDefinition } from "@eavfw/quickform-core"
-//export type QuickFormElement = {
-//    type: "question",
-//    ref: string
-//}
-//export type QuickFormColumn = {
-//    rows: {
-//        [key: string]: QuickFormElement
-//    }
-//}
-//export type QuickFormRow = {
-//    columns: {
-//        [key: string]: QuickFormElement /* | QuickFormColumn this is not supported in designer yet */
-//    }
-//};
-//export type QuickFormSlide = {
-//    title: string
-//    logicalName?: string;
-//    schemaName?: string,
-//    rows?: {
-//        [key: string]: QuickFormRow
-//    }
-//}
-//export type QuickFormQuestion = {
-//    inputType?: string,
-//    text: string
-//    logicalName?: string;
-//    schemaName?: string;
-//}
+import { QuickFormDefinition } from "@eavfw/quickform-core";
+
 export type QuickFormDesignerDefinition = {
     __designer: {
         activeView?: ViewNames;
@@ -36,20 +9,4 @@ export type QuickFormDesignerDefinition = {
         activeQuestion?: string;
     },
     designerLocale?: Locale,
-    //intro: {
-
-    //},
-    //submit: {
-
-    //},
-    //ending: {
-
-    //},
-    //layout: {
-    //    slides: { [key: string]: QuickFormSlide }
-
-    //},
-    //questions: {
-    //    [key: string]: QuickFormQuestion
-    //}
-} & QuickFormDefinition
+} & QuickFormDefinition;

--- a/packages/playground/analyze.js
+++ b/packages/playground/analyze.js
@@ -1,0 +1,18 @@
+
+// More info here : https://blog.jakoblind.no/webpack-bundle-analyzer/#should-you-analyze-the-production-or-dev-bundle
+
+const webpack = require("webpack")
+const BundleAnalyzerPlugin =
+  require("webpack-bundle-analyzer").BundleAnalyzerPlugin
+  const webpackConfigProd = require("./webpack.config");
+// const webpackConfigProd = require("webpack.config")(
+//   "production"
+// )
+
+webpackConfigProd.plugins.push(new BundleAnalyzerPlugin())
+
+webpack(webpackConfigProd, (err, stats) => {
+  if (err || stats.hasErrors()) {
+    console.error(err)
+  }
+})

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -20,13 +20,15 @@
     "ts-loader": "^9.5.1",
     "typescript": "5.4.2",
     "webpack": "^5.89.0",
+    "webpack-bundle-analyzer": "^4.10.2",
     "webpack-cli": "^5.1.4",
     "webpack-dev-server": "^4.15.1"
   },
   "scripts": {
     "start": "webpack-dev-server --mode development --open --hot",
     "dev": "npm run start",
-    "build": "webpack --mode production"
+    "build": "webpack --mode production",
+    "analyze-bundle": "node analyze.js"
   },
   "files": [
     "src"


### PR DESCRIPTION
- Quickform preview can be added to designer settings view
- Added a '<ModernQuickformContainer />' for use
- Now able to define quickformdefinition.layout.showPressEnter as true or false to show or hide "Tryk Enter ->" text on slide button by default
- Now able to define quickformdefinition.layout.defaultSlideButtonIcon as "Email" | "Phone" | "User" | "Checkmark" | "None". This is overwritten if the slide object itself has a icon defined