### PR TITLE
Kba/enter key fix

### DIFF
--- a/packages/core/src/components/intro/Intro.tsx
+++ b/packages/core/src/components/intro/Intro.tsx
@@ -13,7 +13,7 @@ export const Intro: React.FC<IntroProps> = ({ model, onBtnClick }) => {
     const { text, paragraph, buttonText } = model;
 
     /* Listens to enter key pressed */
-    useHandleEnterKeypress("intro", false, onBtnClick);
+    useHandleEnterKeypress(false, onBtnClick);
 
     return (
         <div style={introStyling}>

--- a/packages/core/src/components/question/input-types/baseinput/BaseInputComponent.tsx
+++ b/packages/core/src/components/question/input-types/baseinput/BaseInputComponent.tsx
@@ -130,7 +130,7 @@ export const BaseInputComponent: React.FC<BaseInputComponentProps> = ({ question
     /**
      * While a base input component is active we should answer the question upon enter.
      */
-    useHandleEnterKeypress("baseinput", !questionModel.isActive, () => {
+    useHandleEnterKeypress(!questionModel.isActive, () => {
         answerQuestion(questionModel.logicalName, text, false);
     });
 

--- a/packages/core/src/components/renderers/slide-renderer/SlideRenderer.tsx
+++ b/packages/core/src/components/renderers/slide-renderer/SlideRenderer.tsx
@@ -25,7 +25,7 @@ export const SlideRenderer: React.FC = () => {
     // console.log("showPressEnterCurrentSlide", currentSlide);
 
     /* Listens to enter key pressed */
-    useHandleEnterKeypress("slide", showPressEnter === false, goToNextSlide);
+    useHandleEnterKeypress(false, goToNextSlide);
 
     let nextAllowedEffectTime = useRef(new Date().getTime());
     useEffect(() => {

--- a/packages/core/src/components/renderers/slide-renderer/SlideRenderer.tsx
+++ b/packages/core/src/components/renderers/slide-renderer/SlideRenderer.tsx
@@ -14,15 +14,13 @@ export const SlideRenderer: React.FC = () => {
     const [className, setClassName] = useState(state.classes.slide);
 
     const currentSlide: SlideModel = state.slides[state.currIdx];
-    const buttonText: string = currentSlide?.buttonText ?? "OK";
-    // If not disabled by state.showPressEnter being set to false, and if the slide has questions, and all questions are not multilinetext, show the press enter message
-    const showPressEnter: boolean = (state.showPressEnter === false) ? false : (currentSlide?.questions !== undefined && currentSlide.questions.every(q => q.inputType !== "multilinetext" || !q.isActive));
 
-    /* KBA - Leaving this for now - have to get back to it since we never actually set .isActive property on question.. so we cant use it to condition with at the moment.. */
-    // const showPressEnter: boolean = currentSlide.questions.some(q => q.inputType === "multilinetext" && q.isActive) === false;
-    // console.log("showPressEnter", showPressEnter);
-    // console.log("showPressEnterCondition", currentSlide?.questions?.some(q => q.inputType === "multilinetext" && q.isActive));
-    // console.log("showPressEnterCurrentSlide", currentSlide);
+    // Determine whether to show the "Press Enter" message:
+    // 1. Only show if `state.showPressEnter` is not explicitly set to `false`.
+    // 2. The current slide must have questions, and all questions must either:
+    //    a) Not be of type "multilinetext", or
+    //    b) Be inactive.
+    const showPressEnter: boolean = (state.showPressEnter === false) ? false : (currentSlide?.questions !== undefined && currentSlide.questions.every(q => q.inputType !== "multilinetext" || !q.isActive));
 
     /* Listens to enter key pressed */
     useHandleEnterKeypress(false, goToNextSlide);
@@ -53,7 +51,7 @@ export const SlideRenderer: React.FC = () => {
                 showPressEnter={showPressEnter}
                 children={
                     <>
-                        {buttonText}<IconResolver type={currentSlide?.icon ?? state.defaultSlideButtonIcon} style={{ height: '100%', marginLeft: quickformtokens.gap1 }} color={quickformtokens.onPrimary} size={20} />
+                        {currentSlide?.buttonText}<IconResolver type={currentSlide?.icon ?? state.defaultSlideButtonIcon} style={{ height: '100%', marginLeft: quickformtokens.gap1 }} color={quickformtokens.onPrimary} size={20} />
                     </>
                 }
             />

--- a/packages/core/src/components/submit/Submit.tsx
+++ b/packages/core/src/components/submit/Submit.tsx
@@ -30,7 +30,7 @@ export const Submit: React.FC<SubmitProps> = ({ model }) => {
     }
 
     /* Listens to enter key pressed */
-    useHandleEnterKeypress("submit", false, handleSubmit);
+    useHandleEnterKeypress(false, handleSubmit);
 
     return (
         <div style={submitStyling}>

--- a/packages/core/src/hooks/useHandleEnterKeypress.ts
+++ b/packages/core/src/hooks/useHandleEnterKeypress.ts
@@ -1,7 +1,7 @@
 "use client";
 import { useEffect } from "react";
 
-export function useHandleEnterKeypress(inputType: "multilinetext" | string, disabled?: boolean, customFunc?: () => void) {
+export function useHandleEnterKeypress(disabled?: boolean, customFunc?: () => void) {
     useEffect(() => {
         function handleKeypress(event: KeyboardEvent) {
             if (event.key === "Enter") {

--- a/packages/playground/src/components/baseinput/BaseInputComponent.tsx
+++ b/packages/playground/src/components/baseinput/BaseInputComponent.tsx
@@ -129,7 +129,7 @@ export const BaseInputComponent: React.FC<BaseInputComponentProps> = ({ question
     /**
      * While a base input component is active we should answer the question upon enter.
      */
-    useHandleEnterKeypress("baseinput", !questionModel.isActive, () => {
+    useHandleEnterKeypress(!questionModel.isActive, () => {
         answerQuestion(questionModel.logicalName, text, false);
     });
 


### PR DESCRIPTION
- Removed inputType parameter from useHandleEnterKeyPress hook as it was no longer being used.
- Moved defaultNextButtonText out of component as it was being defined two places. It was confusing and the first assignment never had any effect.
- When pressing enter on e.g. a BaseInputComponent, this answers the question. If enter is pressed again and all questions on that slide have been answered - this presses the "Næste", "OK", "Next" button on the slide as was intended now. A wrongful condition was disabling this behaviour before.